### PR TITLE
Fix: cannot load dataset into spark when name and filename mismatch

### DIFF
--- a/src/synthesized_datasets/_datasets.py
+++ b/src/synthesized_datasets/_datasets.py
@@ -62,8 +62,8 @@ class _Dataset:
             spark = _ps.SparkSession.builder.getOrCreate()
 
         spark.sparkContext.addFile(self.url)
-        _, ext = _os.path.splitext(self.url)
-        df = spark.read.csv(_SparkFiles.get("".join([self.name, ext])), header=True, inferSchema=True)
+        _, filename = _os.path.split(self.url)
+        df = spark.read.csv(_SparkFiles.get(filename), header=True, inferSchema=True)
         df.name = self.name
         return df
 


### PR DESCRIPTION
Could not load dataset into spark when filename did not match the dataset name. This PR uses the filename rather than the dataset name when loading the file into a spark df to avoid errors when there is a mismatch 