### PR TITLE
Use python3.8 compatible typing

### DIFF
--- a/src/synthesized_datasets/_dtypes.py
+++ b/src/synthesized_datasets/_dtypes.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Dict
 
 import pyspark.sql.types as st
 
@@ -20,12 +21,12 @@ class DType(str, Enum):
     TIME = "time"
 
 
-def create_pandas_schema(schema: dict[str, DType]) -> dict[str, str]:
+def create_pandas_schema(schema: Dict[str, DType]) -> Dict[str, str]:
     """Creates a PySpark schema from a dictionary of column names and d"""
     return {name: _PD_DTYPE_MAP[dtype] for name, dtype in schema.items()}
 
 
-def create_pyspark_schema(schema: dict[str, DType]) -> st.StructType:
+def create_pyspark_schema(schema: Dict[str, DType]) -> st.StructType:
     """Creates a PySpark schema from a dictionary of column names and d"""
     return st.StructType(
         [


### PR DESCRIPTION
Currently using `dict` as a type annotation in `_dtypes.py`. This isn't compatible with python 3.8 and can easily be replaced with `typing.Dict`.